### PR TITLE
Get user list

### DIFF
--- a/src/main/java/com/toy/thecommerce/domain/user/controller/UserController.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/controller/UserController.java
@@ -1,19 +1,27 @@
 package com.toy.thecommerce.domain.user.controller;
 
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
+import com.toy.thecommerce.domain.user.dto.UserListResponse;
 import com.toy.thecommerce.domain.user.service.UserService;
+import com.toy.thecommerce.domain.user.type.UserListSort;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "user", description = "회원 API")
@@ -37,5 +45,28 @@ public class UserController {
     userService.signUp(request);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
+
+  @GetMapping("list")
+  @Operation(summary = "회원목록 조회", description = "가입한 회원정보를 조회하여 페이지 처리하여 반환합니다.\n"
+      + "- 각 회원정보는 userId, nickname, username, phone, email을 마스킹 처리하여 반환합니다.\n"
+      + "- 정렬기준 : 가입일순, 회원명순\n"
+      + "- 가입일순으로 정렬 시 내림차순으로 반환\n"
+      + "- 회원명순으로 정렬 시 오름차순으로 반환" )
+  @ApiResponse(responseCode = "200", description = "회원목록 조회 성공")
+  public Page<UserListResponse> getUserList(
+      @Parameter(description = "요청 페이지 숫자를 입력하세요.")
+      @Positive @RequestParam(defaultValue = "0") int page,
+      @Parameter(description = "1페이지 당 보여줄 Element 숫자를 입력하세요.")
+      @Positive @RequestParam(defaultValue = "10") int size,
+      @Parameter(description = "정렬 기준을 입력해 주세요.(createdAt 또는 username 대소문자 구분 불필요)\n")
+      @RequestParam(defaultValue = "createdAt") UserListSort sort) {
+
+    Direction direction = sort == UserListSort.CREATED_AT ? Direction.DESC : Direction.ASC;
+
+    PageRequest pageRequest = PageRequest.of(page, size, direction, sort.getCode());
+
+    return userService.getUserList(pageRequest);
+  }
+
 
 }

--- a/src/main/java/com/toy/thecommerce/domain/user/controller/UserController.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "user", description = "회원 API")
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -55,7 +58,7 @@ public class UserController {
   @ApiResponse(responseCode = "200", description = "회원목록 조회 성공")
   public Page<UserListResponse> getUserList(
       @Parameter(description = "요청 페이지 숫자를 입력하세요.")
-      @Positive @RequestParam(defaultValue = "0") int page,
+      @Min(0) @RequestParam(defaultValue = "0") int page,
       @Parameter(description = "1페이지 당 보여줄 Element 숫자를 입력하세요.")
       @Positive @RequestParam(defaultValue = "10") int size,
       @Parameter(description = "정렬 기준을 입력해 주세요.(createdAt 또는 username 대소문자 구분 불필요)\n")

--- a/src/main/java/com/toy/thecommerce/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/dao/UserRepository.java
@@ -2,6 +2,8 @@ package com.toy.thecommerce.domain.user.dao;
 
 import com.toy.thecommerce.domain.user.entity.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByUserId(String userId);
   Optional<User> findByPhone(String phone);
+  Page<User> findAll(Pageable pageable);
 }

--- a/src/main/java/com/toy/thecommerce/domain/user/dto/UserListResponse.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/dto/UserListResponse.java
@@ -1,0 +1,30 @@
+package com.toy.thecommerce.domain.user.dto;
+
+import com.toy.thecommerce.domain.user.entity.User;
+import com.toy.thecommerce.global.utils.MaskingUtils;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserListResponse {
+  private String userId;
+
+  private String nickname;
+
+  private String username;
+
+  private String phone;
+
+  private String email;
+
+  public static UserListResponse maskingUserListResponse(User user) {
+    return UserListResponse.builder()
+        .userId(MaskingUtils.maskingUserIdOrName(user.getUserId()))
+        .nickname(MaskingUtils.maskingUserIdOrName(user.getNickname()))
+        .username(MaskingUtils.maskingUserIdOrName(user.getUsername()))
+        .phone(MaskingUtils.maskingPhone(user.getPhone()))
+        .email(MaskingUtils.maskingEmail(user.getEmail()))
+        .build();
+  }
+}

--- a/src/main/java/com/toy/thecommerce/domain/user/service/UserService.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/service/UserService.java
@@ -6,7 +6,6 @@ import com.toy.thecommerce.domain.user.dto.UserListResponse;
 import com.toy.thecommerce.domain.user.entity.User;
 import com.toy.thecommerce.domain.user.exception.UserException;
 import com.toy.thecommerce.global.type.ErrorCode;
-import com.toy.thecommerce.global.utils.MaskingUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/toy/thecommerce/domain/user/service/UserService.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/service/UserService.java
@@ -2,10 +2,17 @@ package com.toy.thecommerce.domain.user.service;
 
 import com.toy.thecommerce.domain.user.dao.UserRepository;
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
+import com.toy.thecommerce.domain.user.dto.UserListResponse;
 import com.toy.thecommerce.domain.user.entity.User;
 import com.toy.thecommerce.domain.user.exception.UserException;
 import com.toy.thecommerce.global.type.ErrorCode;
+import com.toy.thecommerce.global.utils.MaskingUtils;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +34,17 @@ public class UserService {
 
     String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-    userRepository.save(User.from(request,encodedPassword));
+    userRepository.save(User.from(request, encodedPassword));
   }
+
+  public Page<UserListResponse> getUserList(Pageable pageable) {
+    Page<User> pageResult = userRepository.findAll(pageable);
+
+    List<UserListResponse> userListResponses = pageResult.getContent().stream()
+        .map(UserListResponse::maskingUserListResponse).collect(Collectors.toList());
+
+    return new PageImpl<>(userListResponses, pageable, pageResult.getTotalElements());
+  }
+
 
 }

--- a/src/main/java/com/toy/thecommerce/domain/user/type/UserListSort.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/type/UserListSort.java
@@ -1,0 +1,22 @@
+package com.toy.thecommerce.domain.user.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserListSort {
+  CREATED_AT("createdAt"),
+  USERNAME("username");
+
+  private final String code;
+
+  public static UserListSort find(String source) {
+    for (UserListSort value : values()) {
+      if (value.getCode().equalsIgnoreCase(source)) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException("정렬 기준이 올바르지 않습니다.");
+  }
+}

--- a/src/main/java/com/toy/thecommerce/global/config/WebConfig.java
+++ b/src/main/java/com/toy/thecommerce/global/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.toy.thecommerce.global.config;
+
+import com.toy.thecommerce.global.converter.StringToEnumConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new StringToEnumConverter());
+  }
+}

--- a/src/main/java/com/toy/thecommerce/global/converter/StringToEnumConverter.java
+++ b/src/main/java/com/toy/thecommerce/global/converter/StringToEnumConverter.java
@@ -1,0 +1,11 @@
+package com.toy.thecommerce.global.converter;
+
+import com.toy.thecommerce.domain.user.type.UserListSort;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToEnumConverter implements Converter<String, UserListSort> {
+  @Override
+  public UserListSort convert(String source) {
+    return UserListSort.find(source);
+  }
+}

--- a/src/main/java/com/toy/thecommerce/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/toy/thecommerce/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.fasterxml.jackson.core.io.JsonEOFException;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -46,6 +47,17 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
       MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+    log.error("MethodArgumentTypeMismatchException is occurred. uri:{}",
+        request.getRequestURI());
+
+    return ResponseEntity
+        .status(BAD_REQUEST)
+        .body(ErrorResponse.of(ARGUMENT_NOT_VALID));
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+      ConstraintViolationException e, HttpServletRequest request) {
     log.error("MethodArgumentTypeMismatchException is occurred. uri:{}",
         request.getRequestURI());
 

--- a/src/main/java/com/toy/thecommerce/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/toy/thecommerce/global/exception/GlobalExceptionHandler.java
@@ -9,7 +9,6 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.fasterxml.jackson.core.io.JsonEOFException;
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -47,17 +46,6 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
       MethodArgumentTypeMismatchException e, HttpServletRequest request) {
-    log.error("MethodArgumentTypeMismatchException is occurred. uri:{}",
-        request.getRequestURI());
-
-    return ResponseEntity
-        .status(BAD_REQUEST)
-        .body(ErrorResponse.of(ARGUMENT_NOT_VALID));
-  }
-
-  @ExceptionHandler(ConstraintViolationException.class)
-  public ResponseEntity<ErrorResponse> handleConstraintViolationException(
-      ConstraintViolationException e, HttpServletRequest request) {
     log.error("MethodArgumentTypeMismatchException is occurred. uri:{}",
         request.getRequestURI());
 

--- a/src/main/java/com/toy/thecommerce/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/toy/thecommerce/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.toy.thecommerce.global.exception;
 
+import static com.toy.thecommerce.global.type.ErrorCode.ARGUMENT_NOT_VALID;
 import static com.toy.thecommerce.global.type.ErrorCode.HTTP_MESSAGE_NOT_READABLE;
 import static com.toy.thecommerce.global.type.ErrorCode.INTERNAL_ERROR;
 import static com.toy.thecommerce.global.type.ErrorCode.JSON_EOF_ERROR;
@@ -8,12 +9,14 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.fasterxml.jackson.core.io.JsonEOFException;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -39,6 +42,28 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(BAD_REQUEST)
         .body(ErrorResponse.of(e.getFieldErrors()));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+    log.error("MethodArgumentTypeMismatchException is occurred. uri:{}",
+        request.getRequestURI());
+
+    return ResponseEntity
+        .status(BAD_REQUEST)
+        .body(ErrorResponse.of(ARGUMENT_NOT_VALID));
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+      ConstraintViolationException e, HttpServletRequest request) {
+    log.error("MethodArgumentTypeMismatchException is occurred. uri:{}",
+        request.getRequestURI());
+
+    return ResponseEntity
+        .status(BAD_REQUEST)
+        .body(ErrorResponse.of(ARGUMENT_NOT_VALID));
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
+++ b/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
@@ -1,8 +1,5 @@
 package com.toy.thecommerce.global.utils;
 
-import com.toy.thecommerce.domain.user.dto.UserListResponse;
-import com.toy.thecommerce.domain.user.entity.User;
-
 public class MaskingUtils {
 
   /**

--- a/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
+++ b/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
@@ -1,0 +1,53 @@
+package com.toy.thecommerce.global.utils;
+
+import com.toy.thecommerce.domain.user.dto.UserListResponse;
+import com.toy.thecommerce.domain.user.entity.User;
+
+public class MaskingUtils {
+
+  /**
+   * userId, nickname, username 마스킹 적용
+   * value 길이가 1 또는 2인 경우 : 첫번째 문자를 * 처리 userId의 길이가 3 또는 4인 경우 :
+   * value 길이가 3 또는 4인 경우 : 첫번째, 마지막 문자를 제외하고 * 처리
+   * value 길이가 5 이상인 경우 : 첫번째 문자 이후 3개의 문자를 * 처리
+   */
+  public static String maskingUserIdOrName(String value) {
+    String maskingValue;
+    if (value.length() == 1 || value.length() == 2) {
+      maskingValue = (value.length() == 1) ? "*" : "*" + value.charAt(1);
+    } else if (value.length() == 3 || value.length() == 4) {
+      maskingValue = (value.length() == 3) ? value.charAt(0) + "*" + value.charAt(2)
+          : value.charAt(0) + "**" + value.substring(3);
+    } else {
+      maskingValue = value.charAt(0) + "***" + value.substring(4);
+    }
+    return maskingValue;
+  }
+
+  /**
+   * 이메일 마스킹 적용
+   * '@' 이전의 문자열을 userId, nickname, username과 동일하게 처리
+   */
+  public static String maskingEmail(String email) {
+    String[] splitEmail = email.split("@");
+    return maskingUserIdOrName(splitEmail[0]) + splitEmail[1];
+  }
+
+  /**
+   * 휴대전화번호 마스킹 적용
+   * 가운데 전화번호 3~4자리 **** 처리
+   */
+  public static String maskingPhone(String phone) {
+    phone = addHyphen(phone);
+    return phone.substring(0, 3) + "****" + phone.substring(phone.length() - 4);
+  }
+
+  private static String addHyphen (String phone) {
+    if (phone.contains("-")) {
+      return phone;
+    } else {
+      return phone.replaceAll("(\\d{3})(\\d{3,4})(\\d{4})", "$1-$2-$3");
+    }
+  }
+
+}

--- a/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
+++ b/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
@@ -30,7 +30,7 @@ public class MaskingUtils {
    */
   public static String maskingEmail(String email) {
     String[] splitEmail = email.split("@");
-    return maskingUserIdOrName(splitEmail[0]) + splitEmail[1];
+    return maskingUserIdOrName(splitEmail[0]) + "@" + splitEmail[1];
   }
 
   /**
@@ -39,7 +39,7 @@ public class MaskingUtils {
    */
   public static String maskingPhone(String phone) {
     phone = addHyphen(phone);
-    return phone.substring(0, 3) + "****" + phone.substring(phone.length() - 4);
+    return phone.substring(0, 3) + "-****-" + phone.substring(phone.length() - 4);
   }
 
   private static String addHyphen (String phone) {

--- a/src/test/java/com/toy/thecommerce/global/utils/MaskingUtilsTest.java
+++ b/src/test/java/com/toy/thecommerce/global/utils/MaskingUtilsTest.java
@@ -1,0 +1,60 @@
+package com.toy.thecommerce.global.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MaskingUtilsTest {
+
+  @Test
+  void maskingUserId_whenInputByKorean() {
+    //given
+    String one = "아";
+    String two = "아아";
+    String three = "아아아";
+    String four = "아아아아";
+    String six = "아아아아아아";
+    //when & then
+    assertEquals("*", MaskingUtils.maskingUserIdOrName(one));
+    assertEquals("*아", MaskingUtils.maskingUserIdOrName(two));
+    assertEquals("아*아", MaskingUtils.maskingUserIdOrName(three));
+    assertEquals("아**아", MaskingUtils.maskingUserIdOrName(four));
+    assertEquals("아***아아", MaskingUtils.maskingUserIdOrName(six));
+  }
+
+  @Test
+  void maskingUserId_whenInputByEnglish() {
+    //given
+    String one = "a";
+    String two = "ab";
+    String three = "abc";
+    String four = "abcd";
+    String six = "abcdef";
+    //when & then
+    assertEquals("*", MaskingUtils.maskingUserIdOrName(one));
+    assertEquals("*b", MaskingUtils.maskingUserIdOrName(two));
+    assertEquals("a*c", MaskingUtils.maskingUserIdOrName(three));
+    assertEquals("a**d", MaskingUtils.maskingUserIdOrName(four));
+    assertEquals("a***ef", MaskingUtils.maskingUserIdOrName(six));
+  }
+
+  @Test
+  void maskingEmail() {
+    // given
+    String email = "abcd@test.com";
+    // when & then
+    assertEquals("a**d@test.com", MaskingUtils.maskingEmail(email));
+  }
+
+  @Test
+  void maskingPhoneNumber() {
+    // given
+    String phone1 = "010-0000-0000";
+    String phone2 = "01000000000";
+
+    // when & then
+    assertEquals("010-****-0000", MaskingUtils.maskingPhone(phone1));
+    assertEquals("010-****-0000", MaskingUtils.maskingPhone(phone2));
+  }
+
+}


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
### 회원목록 조회 정렬 기준 enum 및 converter 구현
- 회원목록 조회 시 정렬 기준을 가입일순(createdAt), 회원명순(username)만 가능하게 하도록 정렬기준을 관리하는 enum을 구현함.
- 쿼리스트링으로 주어진 문자열을 enum 객체로 인식할 수 있도록 converter 구현하여 등록함.
### 회원정보 마스킹 처리 기능 구현
- userId, nickname, username, email, phone 을 마스킹 처리
- userId, nickname, username 마스킹 처리 기준
   - value 길이가 1 또는 2인 경우 : 첫번째 문자를 * 처리 userId의 길이가 3 또는 4인 경우 :
   - value 길이가 3 또는 4인 경우 : 첫번째, 마지막 문자를 제외하고 * 처리
   - value 길이가 5 이상인 경우 : 첫번째 문자 이후 3개의 문자를 * 처리
- 이메일 마스킹 처리 기준
   - '@' 이전의 문자열을 userId, nickname, username과 동일하게 처리
- 휴대전화번호 마스킹 적용
   - 가운데 전화번호 3~4자리 **** 처리
### 회원목록 조회 기능 구현
- 가입한 회원정보를 조회하여 페이지 처리하여 반환
  - 각 회원정보는 userId, nickname, username, phone, email을 마스킹 처리하여 반환.
  - 정렬기준 : 가입일순, 회원명순
  - 가입일순으로 정렬 시 내림차순으로 반환
  - 회원명순으로 정렬 시 오름차순으로 반환

### ExceptionHandling 추가
- ConstraintViolationException 추가
  - controller의 requestParam 유효성 검사 실패하여 Exception 발생 시 핸들링하기 위함.
- MethodArgumentTypeMismatchException 추가
  - json문자열을 Enum으로 convert 과정에서 Exception 발생 시 핸들링하기 위함.

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
- 가입한 회원정보를 조회하여 페이지 처리하여 반환합니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
 
- api 테스트 완료
- 테스트 코드 작성 완료

## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->