### PR TITLE
Update user info

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The Commerce Toy project
   - 페이지 형식으로 반환(id, 닉네임, 이름, 전화번호, 이메일 마스킹 처리하여 반환)
 
 ### 회원 정보 수정(/api/user/{로그인 아이디})
-  - PATCH 방식으로 Request Body에 수정할 파라미터만 입력하여 요청
+  - PATCH 방식
+  - 수정 가능한 정보 : username, nickname, phone, emial(userId, password 변경은 별도 api 구성하여 진행하는 것이 보안상 좋을 것으로 판단함.)
+  - Request Body에 username, nickname, phone, email 입력하여 요청(수정하지 않을 인자는 기존 정보 그대로 요청)
   - 로그인 아이디를 입력받아 회원 기가입 여부 확인(미가입 시 예외 발생)
   - 로그인 아이디와 입력받은 파라미터를 통해 본인 회원정보 수정
-  - 수정한 회원정보 전체 반환(회원id, 닉네임, 이름, 전화번호, 이메일)
+  - 수정한 회원정보 전체 반환(회원id, 닉네임, 이름, 전화번호, 이메일, 비밀번호(마스킹 처리))

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Commerce Toy project
 
 ### 회원 정보 수정(/api/user/{로그인 아이디})
   - PATCH 방식
-  - 수정 가능한 정보 : username, nickname, phone, emial(userId, password 변경은 별도 api 구성하여 진행하는 것이 보안상 좋을 것으로 판단함.)
+  - 수정 가능한 정보 : username, nickname, phone, email(userId, password 변경은 별도 api 구성하여 진행하는 것이 보안상 좋을 것으로 판단함.)
   - Request Body에 username, nickname, phone, email 입력하여 요청(수정하지 않을 인자는 기존 정보 그대로 요청)
   - 로그인 아이디를 입력받아 회원 기가입 여부 확인(미가입 시 예외 발생)
   - 로그인 아이디와 입력받은 파라미터를 통해 본인 회원정보 수정

--- a/src/main/java/com/toy/thecommerce/domain/user/controller/UserController.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.toy.thecommerce.domain.user.controller;
 
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
+import com.toy.thecommerce.domain.user.dto.UserInfoResponse;
+import com.toy.thecommerce.domain.user.dto.UserInfoUpdateRequest;
 import com.toy.thecommerce.domain.user.dto.UserListResponse;
 import com.toy.thecommerce.domain.user.service.UserService;
 import com.toy.thecommerce.domain.user.type.UserListSort;
@@ -20,6 +22,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,7 +53,7 @@ public class UserController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
-  @GetMapping("list")
+  @GetMapping("/list")
   @Operation(summary = "회원목록 조회", description = "가입한 회원정보를 조회하여 페이지 처리하여 반환합니다.\n"
       + "- 각 회원정보는 userId, nickname, username, phone, email을 마스킹 처리하여 반환합니다.\n"
       + "- 정렬기준 : 가입일순, 회원명순\n"
@@ -71,5 +75,19 @@ public class UserController {
     return userService.getUserList(pageRequest);
   }
 
+
+  @Operation(summary = "회원정보 수정", description = "가입한 회원의 회원정보를 수정합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "회원정보 수정 성공"),
+      @ApiResponse(responseCode = "404", description = "저장된 회원정보가 없는 경우"),
+  })
+  @PatchMapping("/{userId}")
+  public UserInfoResponse updateUserInfo(
+      @Parameter(description = "회원수정 요청 객체입니다.\n필드 관련 세부내용은 아래 Model을 확인해주세요.")
+      @Valid @RequestBody UserInfoUpdateRequest request,
+      @Parameter(description = "로그인한 회원id입니다.")
+      @PathVariable String userId) {
+    return userService.updateUserInfo(request, userId);
+  }
 
 }

--- a/src/main/java/com/toy/thecommerce/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,34 @@
+package com.toy.thecommerce.domain.user.dto;
+
+import com.toy.thecommerce.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+
+  private String userId;
+
+  private String password;
+
+  private String username;
+
+  private String nickname;
+
+  private String phone;
+
+  private String email;
+
+  public static UserInfoResponse fromEntity(User user, String maskingPassword) {
+    return UserInfoResponse.builder()
+        .userId(user.getUserId())
+        .password(maskingPassword)
+        .username(user.getUsername())
+        .nickname(user.getNickname())
+        .phone(user.getPhone())
+        .email(user.getEmail())
+        .build();
+  }
+
+}

--- a/src/main/java/com/toy/thecommerce/domain/user/dto/UserInfoUpdateRequest.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/dto/UserInfoUpdateRequest.java
@@ -1,0 +1,42 @@
+package com.toy.thecommerce.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInfoUpdateRequest {
+
+  @NotNull(message = "반드시 값이 있어야 합니다.")
+  @Pattern(regexp = "^(?=.*[가-힣a-zA-Z0-9])[가-힣a-zA-Z0-9]{2,10}$",
+      message = "닉네임은 영문 대문자, 소문자, 한글, 숫자를 사용한 공백없는 6~10자여야 합니다.")
+  @Schema(description = "닉네임: 영문 대문자, 소문자, 한글, 숫자를 사용한 공백없는 6~10자")
+  private String nickname;
+
+  @NotNull(message = "반드시 값이 있어야 합니다.")
+  @Pattern(regexp = "^([a-zA-Z]+|[가-힣]+){2,10}$",
+      message = "회원명은 영어 대,소문자만 작성하거나 한글로만 작성된 공백없는 2~10자여야 합니다.")
+  @Schema(description = "회원 이름: 영어 대,소문자만 작성하거나 한글로만 작성된 공백없는 2~10자")
+  private String username;
+
+  @NotNull(message = "반드시 값이 있어야 합니다.")
+  @Pattern(regexp = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$",
+      message = "휴대전화 번호가 유효하지 않습니다.")
+  @Schema(description = "휴대전화번호: '-'없거나 존재하는 11~12자리 숫자")
+  private String phone;
+
+  @NotNull(message = "반드시 값이 있어야 합니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+      message = "이메일 주소가 유효하지 않습니다.")
+  @Schema(description = "이메일")
+  private String email;
+
+}

--- a/src/main/java/com/toy/thecommerce/domain/user/entity/User.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.toy.thecommerce.domain.user.entity;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
+import com.toy.thecommerce.domain.user.dto.UserInfoUpdateRequest;
 import com.toy.thecommerce.global.entity.BaseEntity;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -12,7 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
@@ -46,6 +46,13 @@ public class User extends BaseEntity {
         .phone(request.getPhone())
         .email(request.getEmail())
         .build();
+  }
+
+  public void updateUserInfo(UserInfoUpdateRequest request) {
+    this.nickname = request.getNickname();
+    this.username = request.getUsername();
+    this.phone = request.getPhone();
+    this.email = request.getEmail();
   }
 
 }

--- a/src/main/java/com/toy/thecommerce/domain/user/service/UserService.java
+++ b/src/main/java/com/toy/thecommerce/domain/user/service/UserService.java
@@ -2,10 +2,13 @@ package com.toy.thecommerce.domain.user.service;
 
 import com.toy.thecommerce.domain.user.dao.UserRepository;
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
+import com.toy.thecommerce.domain.user.dto.UserInfoResponse;
+import com.toy.thecommerce.domain.user.dto.UserInfoUpdateRequest;
 import com.toy.thecommerce.domain.user.dto.UserListResponse;
 import com.toy.thecommerce.domain.user.entity.User;
 import com.toy.thecommerce.domain.user.exception.UserException;
 import com.toy.thecommerce.global.type.ErrorCode;
+import com.toy.thecommerce.global.utils.MaskingUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -45,5 +48,14 @@ public class UserService {
     return new PageImpl<>(userListResponses, pageable, pageResult.getTotalElements());
   }
 
+  public UserInfoResponse updateUserInfo(UserInfoUpdateRequest request, String userId) {
+    User user = userRepository.findByUserId(userId)
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
+    user.updateUserInfo(request);
+
+    User savedUser = userRepository.save(user);
+
+    return UserInfoResponse.fromEntity(savedUser, MaskingUtils.getMaskingPassword());
+  }
 }

--- a/src/main/java/com/toy/thecommerce/global/type/ErrorCode.java
+++ b/src/main/java/com/toy/thecommerce/global/type/ErrorCode.java
@@ -3,6 +3,7 @@ package com.toy.thecommerce.global.type;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public enum ErrorCode {
   INTERNAL_ERROR(INTERNAL_SERVER_ERROR, "처리되지 않은 에러가 발생했습니다."),
   DUPLICATE_USER_ID(CONFLICT, "이미 존재하는 아이디입니다."),
   ALREADY_REGISTERED_USER(BAD_REQUEST, "이미 등록된 사용자입니다.(휴대폰 번호 중복)"),
+  USER_NOT_FOUND(NOT_FOUND, "회원이 존재하지 않습니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
+++ b/src/main/java/com/toy/thecommerce/global/utils/MaskingUtils.java
@@ -2,6 +2,8 @@ package com.toy.thecommerce.global.utils;
 
 public class MaskingUtils {
 
+  private static final String MASKING_PASSWORD = "********";
+
   /**
    * userId, nickname, username 마스킹 적용
    * value 길이가 1 또는 2인 경우 : 첫번째 문자를 * 처리 userId의 길이가 3 또는 4인 경우 :
@@ -45,6 +47,10 @@ public class MaskingUtils {
     } else {
       return phone.replaceAll("(\\d{3})(\\d{3,4})(\\d{4})", "$1-$2-$3");
     }
+  }
+
+  public static String getMaskingPassword() {
+    return MASKING_PASSWORD;
   }
 
 }

--- a/src/test/java/com/toy/thecommerce/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/toy/thecommerce/domain/user/controller/UserControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
 import com.toy.thecommerce.domain.user.dto.UserInfoResponse;

--- a/src/test/java/com/toy/thecommerce/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/toy/thecommerce/domain/user/controller/UserControllerTest.java
@@ -2,16 +2,21 @@ package com.toy.thecommerce.domain.user.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toy.thecommerce.domain.user.dto.SignUpRequest;
+import com.toy.thecommerce.domain.user.dto.UserInfoResponse;
+import com.toy.thecommerce.domain.user.dto.UserInfoUpdateRequest;
 import com.toy.thecommerce.domain.user.dto.UserListResponse;
 import com.toy.thecommerce.domain.user.service.UserService;
 import java.util.ArrayList;
@@ -96,7 +101,6 @@ class UserControllerTest {
         .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "username").exists())
         .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "phone").exists())
         .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "email").exists());
-
   }
 
   private void checkSignUpRequestEachField(SignUpRequest request, SignUpRequest captor) {
@@ -153,11 +157,12 @@ class UserControllerTest {
   }
 
   @Test
-  void getUserList_throwArgumentNotValidException_whenInputInvalidPage() throws Exception {
+  void getUserList_throwArgumentNotValidException_whenInputInvalidPage()
+      throws Exception {
     //given
     //when & then
     mockMvc.perform(get("/api/user/list")
-        .contentType(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
             .param("page", "-1"))
         .andExpect(status().is(400))
         .andExpect(jsonPath("$.errorCode").value("ARGUMENT_NOT_VALID"))
@@ -167,7 +172,8 @@ class UserControllerTest {
   }
 
   @Test
-  void getUserList_throwArgumentNotValidException_whenInputInvalidSize() throws Exception {
+  void getUserList_throwArgumentNotValidException_whenInputInvalidSize()
+      throws Exception {
     //given
     //when & then
     mockMvc.perform(get("/api/user/list")
@@ -181,7 +187,8 @@ class UserControllerTest {
   }
 
   @Test
-  void getUserList_throwArgumentNotValidException_whenInputInvalidSort() throws Exception {
+  void getUserList_throwArgumentNotValidException_whenInputInvalidSort()
+      throws Exception {
     //given
     //when & then
     mockMvc.perform(get("/api/user/list")
@@ -192,5 +199,78 @@ class UserControllerTest {
         .andExpect(jsonPath("$.message").value("잘못된 입력입니다."))
         .andDo(print());
 
+  }
+
+  @Test
+  void successUpdateUserInfo() throws Exception {
+    //given
+    UserInfoUpdateRequest request = UserInfoUpdateRequest.builder()
+        .username("테스트")
+        .nickname("nickname")
+        .phone("010-9999-9999")
+        .email("test@test.com")
+        .build();
+
+    UserInfoResponse response = UserInfoResponse.builder()
+        .userId("userId")
+        .password("********")
+        .username("name")
+        .nickname("name")
+        .phone("010-1111-1111")
+        .email("abcd@abcd.com")
+        .build();
+
+    given(userService.updateUserInfo(any(UserInfoUpdateRequest.class),
+        anyString())).willReturn(response);
+    //when & then
+    ResultActions resultActions = mockMvc.perform(patch("/api/user/userId")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andDo(print());
+
+    checkUpdateRequestAndResponseField(resultActions, response);
+  }
+
+  @Test
+  void updateUserInfo_throwArgumentNotValidException_whenInputInvalidArgument() throws Exception {
+    //given
+    UserInfoUpdateRequest request = UserInfoUpdateRequest.builder()
+        .username("테스트!@#")
+        .nickname("nickname!@#")
+        .phone("010-9999-9999111")
+        .email("test@testcom")
+        .build();
+
+    //when & then
+    ResultActions resultActions = mockMvc.perform(patch("/api/user/userId")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().is(400))
+        .andDo(print());
+
+    checkArgumentNotValidEachFieldUpdate(resultActions);
+  }
+
+  private void checkUpdateRequestAndResponseField(ResultActions resultActions,
+      UserInfoResponse response) throws Exception {
+    resultActions
+        .andExpect(jsonPath("$.userId").value(response.getUserId()))
+        .andExpect(jsonPath("$.password").value(response.getPassword()))
+        .andExpect(jsonPath("$.username").value(response.getUsername()))
+        .andExpect(jsonPath("$.nickname").value(response.getNickname()))
+        .andExpect(jsonPath("$.phone").value(response.getPhone()))
+        .andExpect(jsonPath("$.email").value(response.getEmail()));
+  }
+
+  private void checkArgumentNotValidEachFieldUpdate(ResultActions resultActions)
+      throws Exception {
+    resultActions
+        .andExpect(jsonPath("$.errorCode").value("ARGUMENT_NOT_VALID"))
+        .andExpect(jsonPath("$.message").value("잘못된 입력입니다."))
+        .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "nickname").exists())
+        .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "username").exists())
+        .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "phone").exists())
+        .andExpect(jsonPath("$.errors[?(@.field == '%s')]", "email").exists());
   }
 }


### PR DESCRIPTION
<!-- 필요한 경우 팀원들과 의논하여 양식을 변경할 수 있습니다. -->
<!-- PR은 상세히 적어주시는게 좋습니다. -->
<!-- 이해를 돕기위한 이미지를 써도 좋습니다. -->

## Changes
<!-- 어떤점이 변경되었는지 적어주세요. -->
### 회원정보 수정 기능 구현
- 회원정보의 일부만 변경 예정이기 때문에 PATCH 방식 적용
- 수정 가능한 정보 : username, nickname, phone, email(userId, password 변경은 별도 api 구성하여 진행하는 것이 보안상 좋을 것으로 판단함.)
- Request Body에 username, nickname, phone, email 입력하여 요청(수정하지 않을 인자는 기존 정보 그대로 요청)
- 로그인 아이디를 입력받아 회원 기가입 여부 확인(미가입 시 예외 발생)
- 로그인 아이디와 입력받은 파라미터를 통해 본인 회원정보 수정
- 수정한 회원정보 전체 반환(회원id, 닉네임, 이름, 전화번호, 이메일, 비밀번호(마스킹 처리))

## Background
<!-- 이 PR이 진행된 배경을 적어주세요. -->
- 가입한 회원의 회원정보를 수정할 수 있습니다.

## Discuss
<!-- 토론할 내용이 있다면 적어주세요. -->
- userId, password 변경하는 로직의 별도 api 생성 여부

## Execute
<!-- 실행된 결과에 대해 적어주세요. -->
<!-- 어떻게 테스트를 진행했는지, 어떤 검토를 거쳤는지 적어주시면 좋습니다. -->
<!-- 테스트 코드는 중요합니다! -->
 
- api 테스트 완료
- 테스트 코드 작성 완료

## Reference
<!-- 참조한 레퍼런스가 있다면 적어주세요. -->